### PR TITLE
Make sure fastcgi_https has a value

### DIFF
--- a/php/files/etc/nginx/fastcgi.conf
+++ b/php/files/etc/nginx/fastcgi.conf
@@ -1,4 +1,5 @@
 set $fastcgi_port "80";
+set $fastcgi_https "off";
 if ($http_x_forwarded_proto = 'https') {
     set $fastcgi_https "on";
     set $fastcgi_port  "443";


### PR DESCRIPTION
Regular http requests results in `2023/11/30 08:47:38 [warn] 287#287: *65698 using uninitialized "fastcgi_https" variable, client: 10.130.22.1, server: _, request: "GET /health HTTP/1.1", host: "xxxx"` error because fastcgi_https variable is only set for https requests.