### PR TITLE
Backport from hel.fi: Log xdebug errors to a file

### DIFF
--- a/php/files/entrypoints/15-xdebug.sh
+++ b/php/files/entrypoints/15-xdebug.sh
@@ -8,6 +8,7 @@ if [ "$XDEBUG_ENABLE" = "true" ]; then
     echo "- Already enabled..."
   else
     sudo mv "$XDEBUG_INI".disabled "$XDEBUG_INI"
+    sudo -u root touch /tmp/xdebug.log && sudo chmod 666 /tmp/xdebug.log
   fi
 else
   echo "- Start with Xdebug disabled. Add XDEBUG_ENABLE=true ENV variable to enable it."

--- a/php/files/etc/php/conf.d/xdebug.ini
+++ b/php/files/etc/php/conf.d/xdebug.ini
@@ -3,3 +3,4 @@ zend_extension=xdebug.so
 xdebug.mode=debug
 xdebug.client_host=host.docker.internal
 xdebug.idekey=PHPSTORM
+xdebug.log=/tmp/xdebug.log


### PR DESCRIPTION
Running any php operation when xdebug is enabled, but the client is not running fills the stdout with hundreds of` Xdebug: [Step Debug] Could not connect to debugging client. Tried: 172.22.0.1:9003 (through xdebug.client_host/xdebug.client_port).` warnings.

We've been using this fix since early 2024, but the hel.fi implementation is a bit different (https://github.com/City-of-Helsinki/drupal-docker-images/blob/main/local/drupal/Dockerfile#L19) and I don't have time to actually test if this works.