### PR TITLE
Support for SOLR9 images

### DIFF
--- a/misc/docker-bake.hcl
+++ b/misc/docker-bake.hcl
@@ -9,7 +9,8 @@ variable SIMPLESAMLPHP_VERSION {
 group "default" {
   #targets = ["curl", "s3-sync", "saml-idp", "solr", "varnish"]
   #targets = ["s3-sync", "saml-idp", "solr", "varnish"]
-  targets = ["s3-sync", "saml-idp", "solr"]
+  #targets = ["s3-sync", "saml-idp", "solr"]
+  targets = ["s3-sync", "saml-idp", "solr", "solr8"]
 }
 
 target "common" {
@@ -53,6 +54,14 @@ target "solr" {
   inherits = ["common"]
   context = "./misc/solr"
   target = "solr"
+  tags = ["druidfi/solr:9-drupal","druidfi/solr:9.8.1-drupal"]
+}
+
+target "solr8" {
+  inherits = ["common"]
+  context = "./misc/solr"
+  dockerfile = "Dockerfile.solr8"
+  target = "solr8"
   tags = ["druidfi/solr:8-drupal","druidfi/solr:8.11-drupal"]
 }
 

--- a/misc/solr/Dockerfile
+++ b/misc/solr/Dockerfile
@@ -1,28 +1,38 @@
 # syntax=docker/dockerfile:1
 # check=skip=InvalidBaseImagePlatform
 
+### Git downloader for search_api_solr
+FROM alpine AS git-downloader
+
+RUN apk --update --no-cache add git
+
+WORKDIR /tmp
+
+RUN git clone https://git.drupalcode.org/project/search_api_solr.git
+
+
 #
 # AMD64
 #
-FROM --platform=linux/amd64 solr:8.11-slim AS solr-8-amd64
+FROM --platform=linux/amd64 solr:9.8.1-slim AS solr-9-amd64
 
 ENV ARCH=amd64
 
 #
 # ARM64
 #
-FROM --platform=linux/arm64 arm64v8/solr:8.11-slim AS solr-8-arm64
+FROM --platform=linux/arm64 arm64v8/solr:9.8.1-slim AS solr-9-arm64
 
 ENV ARCH=arm64
 
 #
 # Final
 #
-FROM solr-8-${TARGETARCH} AS solr
+FROM solr-9-${TARGETARCH} AS solr
 
 ENV SOLR_HEAP="1024m" \
-    SOLR_DEFAULT_CONFIG_SET="search_api_solr_4.3.0"
+    SOLR_DEFAULT_CONFIG_SET="search_api_solr_4.3.8"
 
 RUN rm -rf /opt/docker-solr/configsets/
 
-COPY --from=wodby/solr:8 /opt/docker-solr/configsets/ /opt/docker-solr/configsets/
+COPY --from=git-downloader /tmp/search_api_solr/jump-start/solr9/config-set/ /opt/docker-solr/configsets/

--- a/misc/solr/Dockerfile.solr8
+++ b/misc/solr/Dockerfile.solr8
@@ -1,0 +1,28 @@
+# syntax=docker/dockerfile:1
+# check=skip=InvalidBaseImagePlatform
+
+#
+# AMD64
+#
+FROM --platform=linux/amd64 solr:8.11-slim AS solr-8-amd64
+
+ENV ARCH=amd64
+
+#
+# ARM64
+#
+FROM --platform=linux/arm64 arm64v8/solr:8.11-slim AS solr-8-arm64
+
+ENV ARCH=arm64
+
+#
+# Final
+#
+FROM solr-8-${TARGETARCH} AS solr8
+
+ENV SOLR_HEAP="1024m" \
+    SOLR_DEFAULT_CONFIG_SET="search_api_solr_4.3.0"
+
+RUN rm -rf /opt/docker-solr/configsets/
+
+COPY --from=wodby/solr:8 /opt/docker-solr/configsets/ /opt/docker-solr/configsets/


### PR DESCRIPTION
Build target `solr` now builds image for Solr9.
Build target `solr8` added and it builds Solr8 image as earlier.