### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -1,5 +1,8 @@
 name: Database images
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/druidfi/docker-images/security/code-scanning/3](https://github.com/druidfi/docker-images/security/code-scanning/3)

To fix the issue, add a `permissions` block at the root level of the workflow file to explicitly limit the `GITHUB_TOKEN` permissions. Since the workflow primarily involves building database images and does not require `write` access, the permissions can be set to `contents: read`. This ensures the workflow operates with the minimum required privileges.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
