### PR TITLE
CYB-497 Set STARTTLS command to SMTP protocol

### DIFF
--- a/php/rootfs/etc/msmtprc
+++ b/php/rootfs/etc/msmtprc
@@ -1,6 +1,8 @@
 defaults
 tls ${MSMTP_TLS:-off}
 
+tls_starttls ${MSMTP_TLS_STARTTLS:-on}
+
 account default
 auth ${MSMTP_AUTH:-off}
 

--- a/php/rootfs/etc/msmtprc
+++ b/php/rootfs/etc/msmtprc
@@ -1,5 +1,5 @@
 defaults
-tls ${MSMTP_TLS:-off}
+tls ${MSMTP_TLS:-on}
 
 tls_starttls ${MSMTP_TLS_STARTTLS:-on}
 


### PR DESCRIPTION
## Changes requested
These changes requested emerged from a risk [CYB-496](https://druidfi.atlassian.net/browse/CYB-496) that resulted a task [CYB-497](https://druidfi.atlassian.net/browse/CYB-497).

Set STARTTLS as ON to start encryption after the connection has already been established, once the STARTTLS command is sent and the TLS handshake is successfully completed.

Mailjet recommends settings port to 587 and tls_starttls as ON: https://www.mailjet.com/blog/email-best-practices/which-smtp-port-mailjet/
Mailtrap's article from 2024 recommends setting port to 465 and tls_starttls as OFF:  https://mailtrap.io/blog/starttls-ssl-tls/

Though Mailtraps article seems to prove a point, I believe we should follow Mailjet's recommendadtions to set the STARTTLS as on.

After this change the env variables for _production instances_ should be:
```
MSMTP_HOST=<mailjet-host> --> ✅
MSMTP_PORT=587 --> currently our production instances point to 25 -> change to 587
MSMTP_TLS=on --> currently we set this as OFF in drupal-web, we could set it ON by default and set it OFF only for local development to avoid mistakes in production instances where the MSMTP_TLS is being left as OFF: this causes the data be sent uncrypted and as plain text.
MSMTP_AUTH=login --> ✅ 
MSMTP_USER=<mailjet-api-key> --> ✅
MSMTP_PASS=<mailjet-secret-key> --> ✅
```

After this change the env variables for _local environment_ should be:
```
MSMTP_TLS=off --> currently we set this as OFF in drupal-web, we could set it ON by default and set it OFF only for local development to avoid mistakes in production instances where the MSMTP_TLS is being left as OFF: this causes the data be sent uncrypted and as plain text.
```

About the values:
port=25 --> 25 seems to accept anything, but it isn't secure by design: when digging into why 25 is considered unsafe, most reasons refer to its original usage being for open relay (server accepts emails from anyone and forwards it to anyone). Port 587 is designed for authenticated submission and is expected to be used with encryption.

tls --> this value means the connection is encrypted from the very start

starttls --> this value means a command that is being sent to Mailjet telling it basically "start encrypting data after this command", after which Mailjet acknowledges -> handshake happens (key exchange, certificate verification) -> things get encrypted

If and when we would merge this MR, the Mailjet should continue accepting the mail even with port 25. What we would need to do anyhow for **all projects sending emails** is:
- change the port 25 -> 587
- for local development, we need to set MSMTP_TLS=off: without that the local mail processing to Mailpit wont work. Its safer to set MSMTP_TLS=on by default, so there wont be "whoopsies" when forgetting to put it on for production instances, which would mean the data is being sent unencrypted.

To test the email sending we can use this (change the email names):
```
echo -e "From: etunimi.sukunimi@druid.fi\nSubject: Test\n\nTest body with port 587" | msmtp -v -f test@localhost etunimi.sukunimi@druid.fi
```

[CYB-496]: https://druidfi.atlassian.net/browse/CYB-496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CYB-497]: https://druidfi.atlassian.net/browse/CYB-497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ